### PR TITLE
Fix error when using hidden_layer=-1

### DIFF
--- a/byol_pytorch/byol_pytorch.py
+++ b/byol_pytorch/byol_pytorch.py
@@ -124,11 +124,11 @@ class NetWrapper(nn.Module):
         return projector.to(hidden)
 
     def get_representation(self, x):
-        if not self.hook_registered:
-            self._register_hook()
-
         if self.layer == -1:
             return self.net(x)
+
+        if not self.hook_registered:
+            self._register_hook()
 
         _ = self.net(x)
         hidden = self.hidden


### PR DESCRIPTION
Fix "Only Tensors created explicitly by the user (graph leaves) support the deepcopy protocol at the moment" error when using hidden_layer=-1