### PR TITLE
Use Torchvision augmentations instead of Kornia, which work with TPUs

### DIFF
--- a/byol_pytorch/byol_pytorch.py
+++ b/byol_pytorch/byol_pytorch.py
@@ -168,18 +168,16 @@ class BYOL(nn.Module):
         # default SimCLR augmentation
 
         DEFAULT_AUG = torch.nn.Sequential(
-            T.RandomApply(
-                torch.nn.ModuleList(
-                    [ T.ColorJitter(0.8, 0.8, 0.8, 0.2) ]
-                )
-            , p = 0.3),
+            RandomApply(
+                T.ColorJitter(0.8, 0.8, 0.8, 0.2),
+                p = 0.3
+            ),
             T.RandomGrayscale(p=0.2),
             T.RandomHorizontalFlip(),
-            T.RandomApply(
-                torch.nn.ModuleList(
-                    [ T.GaussianBlur((3, 3), (1.0, 2.0)) ]
-                )
-            , p = 0.2),
+            RandomApply(
+                T.GaussianBlur((3, 3), (1.0, 2.0)),
+                p = 0.2
+            ),
             T.RandomResizedCrop((image_size, image_size)),
             T.Normalize(
                 mean=torch.tensor([0.485, 0.456, 0.406]),

--- a/byol_pytorch/byol_pytorch.py
+++ b/byol_pytorch/byol_pytorch.py
@@ -6,8 +6,7 @@ import torch
 from torch import nn
 import torch.nn.functional as F
 
-from kornia import augmentation as augs
-from kornia import filters, color
+from torchvision import transforms as T
 
 # helper functions
 
@@ -168,13 +167,23 @@ class BYOL(nn.Module):
 
         # default SimCLR augmentation
 
-        DEFAULT_AUG = nn.Sequential(
-            RandomApply(augs.ColorJitter(0.8, 0.8, 0.8, 0.2), p=0.8),
-            augs.RandomGrayscale(p=0.2),
-            augs.RandomHorizontalFlip(),
-            RandomApply(filters.GaussianBlur2d((3, 3), (1.5, 1.5)), p=0.1),
-            augs.RandomResizedCrop((image_size, image_size)),
-            augs.Normalize(mean=torch.tensor([0.485, 0.456, 0.406]), std=torch.tensor([0.229, 0.224, 0.225]))
+        DEFAULT_AUG = torch.nn.Sequential(
+            T.RandomApply(
+                torch.nn.ModuleList(
+                    [ T.ColorJitter(0.8, 0.8, 0.8, 0.2) ]
+                )
+            , p = 0.3),
+            T.RandomGrayscale(p=0.2),
+            T.RandomHorizontalFlip(),
+            T.RandomApply(
+                torch.nn.ModuleList(
+                    [ T.GaussianBlur((3, 3), (1.0, 2.0)) ]
+                )
+            , p = 0.2),
+            T.RandomResizedCrop((image_size, image_size)),
+            T.Normalize(
+                mean=torch.tensor([0.485, 0.456, 0.406]),
+                std=torch.tensor([0.229, 0.224, 0.225])),
         )
 
         self.augment1 = default(augment_fn, DEFAULT_AUG)

--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ setup(
   keywords = ['self-supervised learning', 'artificial intelligence'],
   install_requires=[
       'torch>=1.6',
-      'kornia>=0.4.0'
+      'torchvision>=0.8'
   ],
   classifiers=[
       'Development Status :: 4 - Beta',


### PR DESCRIPTION
This commit substitutes the Kornia augmentations in the BYOL class with
augmentations which come from the torchvision package.

Apparently, Kornia augmentations were the culprit for the error
of issue #33 

The example `train.py` script works on Colab TPUs out of the box after this
commit (not considering Lightning's problem [here](https://github.com/PyTorchLightning/pytorch-lightning/issues/4829), which can be solved by changing a line in the `pytorch_lightning.utilities.xla_device_utils` module).